### PR TITLE
refactor(auth): remove captcha token persistence from Supabase

### DIFF
--- a/pikpak-plus-server/app/core/token_manager.py
+++ b/pikpak-plus-server/app/core/token_manager.py
@@ -138,45 +138,39 @@ class TokenManager:
 
     def get_all_tokens(self) -> Dict[str, Optional[str]]:
         """
-        Get all tokens including access, refresh, captcha, and user_id
+        Get all tokens including access, refresh, and user_id
+        Note: Captcha tokens are managed via Redis, not Supabase
 
         Returns:
-            Dict with all token fields
+            Dict with token fields
         """
         row = self._get_tokens_row()
         if row:
             return {
                 'access_token': row.get('access_token'),
                 'refresh_token': row.get('refresh_token'),
-                'user_id': row.get('user_id'),
-                'captcha_token': row.get('captcha_token'),
-                'captcha_expires_at': row.get('captcha_expires_at')
+                'user_id': row.get('user_id')
             }
         return {
             'access_token': None,
             'refresh_token': None,
-            'user_id': None,
-            'captcha_token': None,
-            'captcha_expires_at': None
+            'user_id': None
         }
 
     def set_tokens(
         self,
         access_token: str = None,
         refresh_token: str = None,
-        user_id: str = None,
-        captcha_token: str = None,
-        captcha_expires_at: str = None
+        user_id: str = None
     ):
         """
-        Store tokens including optional captcha and user_id
+        Store tokens in Supabase
+        Note: Captcha tokens are managed via Redis, not Supabase
 
         Args:
             access_token: Access token string
             refresh_token: Refresh token string
             user_id: PikPak user ID
-            captcha_token: Captcha token string
-            captcha_expires_at: Captcha expiration timestamp (ISO format)
         """
         data = {}
         if access_token is not None:
@@ -185,10 +179,6 @@ class TokenManager:
             data['refresh_token'] = refresh_token
         if user_id is not None:
             data['user_id'] = user_id
-        if captcha_token is not None:
-            data['captcha_token'] = captcha_token
-        if captcha_expires_at is not None:
-            data['captcha_expires_at'] = captcha_expires_at
 
         if data:
             self._update_tokens_row(data)
@@ -198,9 +188,7 @@ class TokenManager:
         self._update_tokens_row({
             'access_token': None,
             'refresh_token': None,
-            'user_id': None,
-            'captcha_token': None,
-            'captcha_expires_at': None
+            'user_id': None
         })
 
     def clear_all(self):

--- a/pikpak-plus-server/app/services/pikpak_service.py
+++ b/pikpak-plus-server/app/services/pikpak_service.py
@@ -156,7 +156,6 @@ class PikPakService:
         """Reload tokens from Supabase into the client."""
         try:
             from app.core.token_manager import get_token_manager
-            from datetime import datetime
             token_mgr = get_token_manager()
             tokens = token_mgr.get_all_tokens()
 
@@ -170,29 +169,8 @@ class PikPakService:
                 else:
                     self._extract_user_id_from_token()
 
-                # Load captcha token if available and not expired
-                # IMPORTANT: Only use captcha if it's for the same user
-                stored_user_id = tokens.get('user_id')
-                if (tokens.get('captcha_token') and tokens.get('captcha_expires_at')
-                        and stored_user_id and stored_user_id == self.client.user_id):
-                    expires_at_str = tokens['captcha_expires_at']
-                    try:
-                        # Parse ISO format timestamp
-                        if isinstance(expires_at_str, str):
-                            expires_at = datetime.fromisoformat(
-                                expires_at_str.replace('Z', '+00:00'))
-                            self.client.captcha_expires_at = expires_at.timestamp()
-                        else:
-                            self.client.captcha_expires_at = float(
-                                expires_at_str)
-
-                        # Check if still valid (30 second buffer)
-                        import time
-                        if time.time() < (self.client.captcha_expires_at - 30):
-                            self.client.captcha_token = tokens['captcha_token']
-                            logger.info("Loaded captcha token from Supabase")
-                    except Exception as e:
-                        logger.warning(f"Failed to parse captcha expiry: {e}")
+                # Note: Captcha tokens are managed locally (short-lived, ~5 mins)
+                # No need to persist/reload from Supabase
 
                 logger.debug("Reloaded tokens from Supabase")
         except Exception as e:
@@ -224,33 +202,9 @@ class PikPakService:
                 action="GET:/drive/v1/about"
             )
             logger.info("Captcha token generated successfully")
-
-            # Save captcha token to Supabase for other workers
-            await self._save_captcha_to_supabase()
         except Exception as e:
             logger.error(f"Failed to generate captcha token: {e}")
             raise
-
-    async def _save_captcha_to_supabase(self) -> None:
-        """Save current captcha token to Supabase for sharing across workers."""
-        try:
-            from app.core.token_manager import get_token_manager
-            from datetime import datetime, timezone
-
-            if self.client.captcha_token and self.client.captcha_expires_at:
-                token_mgr = get_token_manager()
-                expires_at = datetime.fromtimestamp(
-                    self.client.captcha_expires_at, tz=timezone.utc
-                ).isoformat()
-
-                token_mgr.set_tokens(
-                    user_id=self.client.user_id,
-                    captcha_token=self.client.captcha_token,
-                    captcha_expires_at=expires_at
-                )
-                logger.debug("Saved captcha token to Supabase")
-        except Exception as e:
-            logger.warning(f"Failed to save captcha to Supabase: {e}")
 
     def _extract_user_id_from_token(self) -> None:
         """
@@ -334,24 +288,15 @@ class PikPakService:
             logger.info("Performing PikPak login...")
             await self.client.login()
 
-            # Save new tokens to Supabase (including user_id and captcha)
+            # Save new tokens to Supabase (access, refresh, user_id)
+            # Note: Captcha tokens are managed locally (short-lived, ~5 mins)
             from app.core.token_manager import get_token_manager
-            from datetime import datetime, timezone
             token_mgr = get_token_manager()
-
-            # Prepare captcha expiry timestamp
-            captcha_expires_at = None
-            if self.client.captcha_expires_at:
-                captcha_expires_at = datetime.fromtimestamp(
-                    self.client.captcha_expires_at, tz=timezone.utc
-                ).isoformat()
 
             token_mgr.set_tokens(
                 access_token=self.client.access_token,
                 refresh_token=self.client.refresh_token,
-                user_id=self.client.user_id,
-                captcha_token=self.client.captcha_token,
-                captcha_expires_at=captcha_expires_at
+                user_id=self.client.user_id
             )
             logger.info("Updated tokens in Supabase after login")
 

--- a/pikpak-plus-server/supabase_schema.sql
+++ b/pikpak-plus-server/supabase_schema.sql
@@ -73,6 +73,8 @@ CREATE INDEX IF NOT EXISTS idx_public_actions_file_id ON public_actions((data->>
 
 
 -- Table for storing PikPak tokens (Singleton row)
+-- Note: captcha_token and captcha_expires_at columns are DEPRECATED
+-- Captcha tokens are now managed in-memory (short-lived, ~5 mins)
 CREATE TABLE IF NOT EXISTS pikpak_tokens (
     id INTEGER PRIMARY KEY DEFAULT 1,
     username TEXT,
@@ -82,8 +84,8 @@ CREATE TABLE IF NOT EXISTS pikpak_tokens (
     access_token_expires_at TIMESTAMP WITH TIME ZONE,
     refresh_token_expires_at TIMESTAMP WITH TIME ZONE,
     user_id TEXT,
-    captcha_token TEXT,
-    captcha_expires_at TIMESTAMP WITH TIME ZONE,
+    captcha_token TEXT,              -- DEPRECATED: kept for backward compatibility
+    captcha_expires_at TIMESTAMP WITH TIME ZONE,  -- DEPRECATED: kept for backward compatibility
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     CONSTRAINT single_row CHECK (id = 1)
 );


### PR DESCRIPTION
- Captcha tokens are now managed in-memory via Redis due to their short-lived nature (~5 minutes)
- Removed captcha_token and captcha_expires_at from token storage operations
- Updated Supabase schema to mark captcha columns as deprecated
- Simplified token management by removing unnecessary persistence logic

BREAKING CHANGE: Captcha tokens are no longer persisted in Supabase database

## Pull Request Type

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My commit message follows the conventional commit format
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

## Commit Message Format

Please ensure your commit message follows the conventional commit format:

```
<type>[optional scope]: <description>

[optional body]

[optional footer(s)]
```

Examples:
- `feat: add user authentication system`
- `fix: resolve issue with file download`
- `docs: update API documentation`

For breaking changes, include in the footer:
```
BREAKING CHANGE: description of breaking change
```

This helps with automated release generation and changelog creation.