### PR TITLE
feat(webdav): add modify_webdav_application endpoint and read-only support

### DIFF
--- a/pikpak-plus-server/PikPakAPI/webdav.py
+++ b/pikpak-plus-server/PikPakAPI/webdav.py
@@ -2,6 +2,7 @@ import httpx
 from typing import Dict, Any
 from .settings import WEBDAV_BASE_URL, DEFAULT_TIMEOUT
 
+
 class WebDavMixin:
     def _get_webdav_headers(self) -> Dict[str, str]:
         """Get headers for WebDAV API requests"""
@@ -12,17 +13,17 @@ class WebDavMixin:
             "origin": "https://mypikpak.com",
             "referer": "https://mypikpak.com/",
         }
-    
+
     async def get_webdav_applications(self) -> Dict[str, Any]:
         """
         Get WebDAV configuration and application list
         """
         url = f"{WEBDAV_BASE_URL}/webdav/v1/applications"
         headers = self._get_webdav_headers()
-        
+
         # Use self.httpx_client if available, but extended used a new client with specific timeout
         # We can use self.httpx_client but need to ensure headers are correct.
-        # The extended implementation created a new client for each request. 
+        # The extended implementation created a new client for each request.
         # To be consistent with the rest of the API, we should probably use _make_request if possible,
         # but _make_request uses self.httpx_client which might have different config.
         # Also _make_request handles retries and error parsing.
@@ -30,12 +31,12 @@ class WebDavMixin:
         # Let's try to use _make_request but with custom headers and URL.
         # However, _make_request assumes standard PikPak error handling. WebDAV might be different.
         # Let's stick to the extended implementation's logic but use a shared client or create one.
-        
+
         async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
             response = await client.get(url, headers=headers)
             response.raise_for_status()
             return response.json()
-    
+
     async def toggle_webdav(self, enable: bool) -> Dict[str, Any]:
         """
         Toggle WebDAV status on or off
@@ -43,12 +44,12 @@ class WebDavMixin:
         url = f"{WEBDAV_BASE_URL}/webdav/v1/toggle-enable"
         headers = self._get_webdav_headers()
         data = {"enable": enable}
-        
+
         async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
             response = await client.post(url, headers=headers, json=data)
             response.raise_for_status()
             return response.json()
-    
+
     async def create_webdav_application(self, application_name: str) -> Dict[str, Any]:
         """
         Create a new WebDAV application
@@ -56,12 +57,12 @@ class WebDavMixin:
         url = f"{WEBDAV_BASE_URL}/webdav/v1/application"
         headers = self._get_webdav_headers()
         data = {"application_name": application_name}
-        
+
         async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
             response = await client.post(url, headers=headers, json=data)
             response.raise_for_status()
             return response.json()
-    
+
     async def delete_webdav_application(self, username: str, password: str) -> Dict[str, Any]:
         """
         Delete a WebDAV application
@@ -69,8 +70,30 @@ class WebDavMixin:
         url = f"{WEBDAV_BASE_URL}/webdav/v1/application"
         headers = self._get_webdav_headers()
         data = {"username": username, "password": password}
-        
+
         async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
             response = await client.request("DELETE", url, headers=headers, json=data)
+            response.raise_for_status()
+            return response.json()
+
+    async def modify_webdav_application(self, username: str, password: str, modify_props: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Modify WebDAV application properties (e.g., set read_only)
+
+        Args:
+            username: WebDAV application username
+            password: WebDAV application password
+            modify_props: Dictionary of properties to modify (e.g., {"read_only": True})
+        """
+        url = f"{WEBDAV_BASE_URL}/webdav/v1/application"
+        headers = self._get_webdav_headers()
+        data = {
+            "username": username,
+            "password": password,
+            "modify_props": modify_props
+        }
+
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            response = await client.patch(url, headers=headers, json=data)
             response.raise_for_status()
             return response.json()

--- a/pikpak-plus-server/app/api/routes/webdav.py
+++ b/pikpak-plus-server/app/api/routes/webdav.py
@@ -120,6 +120,34 @@ def delete_webdav_application():
     return run_async(_async_delete_webdav_application())
 
 
+@bp.route('/webdav/application', methods=['PATCH'])
+@internal_only
+def modify_webdav_application():
+    """
+    Modify WebDAV application properties (e.g., set read_only)
+
+    INTERNAL ONLY - Not accessible from external systems
+    """
+    async def _async_modify_webdav_application():
+        try:
+            data = request.json
+            username = data.get('username')
+            password = data.get('password')
+            modify_props = data.get('modify_props')
+
+            if not username or not password or not modify_props:
+                return jsonify({"error": "Missing 'username', 'password', or 'modify_props' parameter"}), 400
+
+            pikpak_service = get_pikpak_service()
+            result = await pikpak_service.modify_webdav_application(username, password, modify_props)
+            return jsonify(result)
+        except Exception as e:
+            logger.error(f"Failed to modify WebDAV application: {e}")
+            return jsonify({"error": str(e)}), 500
+
+    return run_async(_async_modify_webdav_application())
+
+
 @bp.route('/webdav/active-clients', methods=['GET'])
 def get_active_webdav_clients():
     """

--- a/pikpak-plus-server/app/services/pikpak_service.py
+++ b/pikpak-plus-server/app/services/pikpak_service.py
@@ -496,6 +496,19 @@ class PikPakService:
 
         return await self._execute_with_retry(_do_delete)
 
+    async def modify_webdav_application(self, username: str, password: str, modify_props: Dict[str, Any]) -> dict:
+        """Modify WebDAV application properties"""
+        if not self.client:
+            raise RuntimeError(PIKPAK_CLIENT_NOT_INITIALIZED)
+
+        async def _do_modify():
+            result = await self.client.modify_webdav_application(username, password, modify_props)
+            logger.info(
+                f"Modified WebDAV application: {username} with props: {modify_props}")
+            return result
+
+        return await self._execute_with_retry(_do_modify)
+
     async def get_offline_tasks(self) -> dict:
         """Get all offline download tasks from PikPak"""
         if not self.client:

--- a/pikpak-plus-server/app/services/webdav/clients.py
+++ b/pikpak-plus-server/app/services/webdav/clients.py
@@ -69,6 +69,17 @@ class ClientManager:
                     username = result.get('username', '')
                     password = result.get('password', '')
 
+                    # Set client as read-only by default
+                    try:
+                        read_only_result = await self.pikpak_service.modify_webdav_application(
+                            username, password, {"read_only": True}
+                        )
+                        logger.info(
+                            f"Set WebDAV client {planet_name} as read-only: {read_only_result}")
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to set read-only for {planet_name}, but client creation succeeded: {e}")
+
                     # Build client info
                     created_at = datetime.now(timezone.utc)
                     expires_at = created_at + timedelta(hours=self.ttl_hours)
@@ -81,7 +92,8 @@ class ClientManager:
                         "serverUrl": server_url,
                         "createdAt": created_at.isoformat() + "Z",
                         "expiresAt": expires_at.isoformat() + "Z",
-                        "ttlHours": self.ttl_hours
+                        "ttlHours": self.ttl_hours,
+                        "readOnly": True  # Mark as read-only in client info
                     }
 
                     created_clients.append(client_info)


### PR DESCRIPTION
- Add new `modify_webdav_application` method to WebDavMixin class
- Implement PATCH endpoint for modifying WebDAV application properties
- Add service layer method in PikPakService for modification
- Set newly created WebDAV clients as read-only by default
- Include read-only status in client info response

The changes enable WebDAV application property modification, particularly for setting read-only access. New clients are now created with read-only access by default for enhanced security.

## Pull Request Type

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My commit message follows the conventional commit format
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

## Commit Message Format

Please ensure your commit message follows the conventional commit format:

```
<type>[optional scope]: <description>

[optional body]

[optional footer(s)]
```

Examples:
- `feat: add user authentication system`
- `fix: resolve issue with file download`
- `docs: update API documentation`

For breaking changes, include in the footer:
```
BREAKING CHANGE: description of breaking change
```

This helps with automated release generation and changelog creation.