### PR TITLE
feat(statistics): update statistics collection schedule to run at UTC midnight

### DIFF
--- a/pikpak-plus-server/app/tasks/jobs/statistics_job.py
+++ b/pikpak-plus-server/app/tasks/jobs/statistics_job.py
@@ -59,9 +59,10 @@ def collect_daily_statistics(self):
                 logger.info(
                     f"Statistics for {target_date_str} already exist. Skipping.")
 
-                # Update Redis status for next check (1 hour later)
+                # Update Redis status for next check (next UTC midnight)
                 from app.tasks.utils import update_redis_status
-                next_run_time = run_time + timedelta(hours=1)
+                next_run_time = (run_time + timedelta(days=1)
+                                 ).replace(hour=0, minute=0, second=0, microsecond=0)
                 update_redis_status(redis_client, run_time,
                                     next_run_time, "statistics_collection")
                 return
@@ -139,8 +140,9 @@ def collect_daily_statistics(self):
             # Update Redis status
             from app.tasks.utils import update_redis_status
 
-            # Check again in 1 hour
-            next_run_time = run_time + timedelta(hours=1)
+            # Check again at next UTC midnight
+            next_run_time = (run_time + timedelta(days=1)
+                             ).replace(hour=0, minute=0, second=0, microsecond=0)
             update_redis_status(redis_client, run_time,
                                 next_run_time, "statistics_collection")
 


### PR DESCRIPTION
The statistics collection job now runs at UTC midnight instead of every hour. This change improves efficiency by aligning the collection with daily boundaries and reduces unnecessary frequent checks. The job will now execute once per day at 00:00 UTC, collecting statistics for the previous day's data.

## Pull Request Type

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My commit message follows the conventional commit format
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

## Commit Message Format

Please ensure your commit message follows the conventional commit format:

```
<type>[optional scope]: <description>

[optional body]

[optional footer(s)]
```

Examples:
- `feat: add user authentication system`
- `fix: resolve issue with file download`
- `docs: update API documentation`

For breaking changes, include in the footer:
```
BREAKING CHANGE: description of breaking change
```

This helps with automated release generation and changelog creation.