### PR TITLE
fix(config): remove exposed Redis port from docker-compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,8 +123,8 @@ services:
 
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
+    # ports:
+    #   - "6379:6379"
     volumes:
       - redis_data:/data
 


### PR DESCRIPTION
The Redis service port mapping has been commented out to prevent external access to the Redis instance, improving security by keeping it internal to the Docker network. This change ensures Redis is only accessible by other services within the same Docker network rather than being exposed to the host machine.

## Pull Request Type

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My commit message follows the conventional commit format
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

## Commit Message Format

Please ensure your commit message follows the conventional commit format:

```
<type>[optional scope]: <description>

[optional body]

[optional footer(s)]
```

Examples:
- `feat: add user authentication system`
- `fix: resolve issue with file download`
- `docs: update API documentation`

For breaking changes, include in the footer:
```
BREAKING CHANGE: description of breaking change
```

This helps with automated release generation and changelog creation.