### PR TITLE
Feature/e2dk link support

### DIFF
--- a/pikpak-plus-client/src/components/features/create-share/magnet-input-card.tsx
+++ b/pikpak-plus-client/src/components/features/create-share/magnet-input-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { CloudDownload, AlertCircle, Clock } from "lucide-react";
+import { CloudDownload, AlertCircle, Clock, Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -11,7 +11,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { validateMagnetLink } from "./magnet-utils";
+import { Badge } from "@/components/ui/badge";
+import { validateDownloadLink } from "./magnet-utils";
 import { addMagnetLink } from "./api-utils";
 
 interface MagnetInputCardProps {
@@ -38,15 +39,16 @@ export function MagnetInputCard({
   const [message, setMessage] = useState("");
   const [validationError, setValidationError] = useState("");
   const [fileInfo, setFileInfo] = useState<any>(null);
+  const [detectedLinkType, setDetectedLinkType] = useState<string | undefined>();
 
   const handleAdd = async () => {
     if (!url.trim()) {
-      setValidationError("Please enter a magnet link");
+      setValidationError("Please enter a download link");
       return;
     }
-    const validation = validateMagnetLink(url);
+    const validation = validateDownloadLink(url);
     if (!validation.valid) {
-      setValidationError(validation.error || "Invalid magnet link");
+      setValidationError(validation.error || "Invalid download link");
       return;
     }
     setLoading(true);
@@ -65,9 +67,10 @@ export function MagnetInputCard({
         setFileInfo(fileInfoData);
       }
 
-      setMessage(result.message || "Magnet link added successfully!");
+      setMessage(result.message || "Link added successfully!");
       onAddSuccess({ ...taskData, url: url.trim() }, fileInfoData); // Pass the URL with task data
       setUrl("");
+      setDetectedLinkType(undefined);
     } catch (error: any) {
       setMessage(error.message);
 
@@ -86,12 +89,46 @@ export function MagnetInputCard({
     }
   };
 
+  // Detect link type as user types
+  const handleUrlChange = (value: string) => {
+    setUrl(value);
+    if (value.trim()) {
+      const validation = validateDownloadLink(value);
+      setDetectedLinkType(validation.linkType);
+    } else {
+      setDetectedLinkType(undefined);
+    }
+  };
+
+  const getLinkTypeColor = (type?: string) => {
+    switch (type) {
+      case "magnet":
+        return "bg-blue-500/20 text-blue-700 dark:text-blue-400";
+      case "e2dk":
+        return "bg-purple-500/20 text-purple-700 dark:text-purple-400";
+      default:
+        return "bg-gray-500/20 text-gray-700 dark:text-gray-400";
+    }
+  };
+
   return (
     <Card className="border-primary/20 shadow-lg shadow-primary/5 w-full">
       <CardHeader className="pb-3 pt-4 px-4">
-        <CardTitle className="text-base">Add Magnet Link</CardTitle>
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <CardTitle className="text-base">Add Download Link</CardTitle>
+            <CardDescription className="text-xs">
+              Supports magnet links and E2DK links
+            </CardDescription>
+          </div>
+          {detectedLinkType && (
+            <Badge className={getLinkTypeColor(detectedLinkType)}>
+              {detectedLinkType.toUpperCase()}
+            </Badge>
+          )}
+        </div>
         {maxFileSizeGB && (
-          <CardDescription className="text-xs">
+          <CardDescription className="text-xs mt-2">
             Maximum file size: {maxFileSizeGB} GB
           </CardDescription>
         )}
@@ -102,11 +139,19 @@ export function MagnetInputCard({
         )}
       </CardHeader>
       <CardContent className="space-y-2 px-4 pt-0.5 pb-4">
+        {/* Info Banner */}
+        <div className="flex items-start gap-2 text-xs bg-blue-50 dark:bg-blue-950/30 p-3 rounded-md border border-blue-200 dark:border-blue-800">
+          <Info className="h-4 w-4 mt-0.5 shrink-0 text-blue-600 dark:text-blue-400" />
+          <span className="text-blue-900 dark:text-blue-300">
+            Enter a <strong>magnet link</strong> (magnet:?xt=urn:btih:...) or an <strong>E2DK link</strong> (ed2k://|file|...|/){" "}
+          </span>
+        </div>
+
         <div className="flex flex-col md:flex-row gap-2">
           <Input
-            placeholder="magnet:?xt=urn:btih:..."
+            placeholder="magnet:?xt=urn:btih:... or ed2k://|file|..."
             value={url}
-            onChange={(e) => setUrl(e.target.value)}
+            onChange={(e) => handleUrlChange(e.target.value)}
             onKeyDown={handleKeyDown}
             className={`flex-1 ${validationError ? "border-destructive" : ""}`}
             disabled={loading}

--- a/pikpak-plus-client/src/components/features/create-share/magnet-utils.ts
+++ b/pikpak-plus-client/src/components/features/create-share/magnet-utils.ts
@@ -16,3 +16,68 @@ export const validateMagnetLink = (
       "Invalid magnet link. Please provide a valid magnet link starting with 'magnet:?xt=urn:btih:'",
   };
 };
+
+// E2DK link validation
+export const validateE2dkLink = (
+  link: string,
+): { valid: boolean; error?: string } => {
+  const trimmedLink = link.trim();
+  if (!trimmedLink) {
+    return { valid: false, error: "Please enter an E2DK link" };
+  }
+
+  // E2DK format: ed2k://|file|filename|size|hash|/
+  // Filename cannot contain pipes (|) as they are used as delimiters
+  // Example: ed2k://|file|example.zip|123456|abcdef1234567890abcdef1234567890|/
+  const e2dkRegex = /^ed2k:\/\/\|file\|[^|]+\|\d+\|[a-f0-9]{32}\|\/$/i;
+  
+  if (e2dkRegex.test(trimmedLink)) {
+    return { valid: true };
+  }
+  return {
+    valid: false,
+    error:
+      "Invalid E2DK link. Please provide a valid E2DK link in format: ed2k://|file|filename|size|hash|/",
+  };
+};
+
+// Universal download link validation
+export const validateDownloadLink = (
+  link: string,
+): { 
+  valid: boolean; 
+  error?: string;
+  linkType?: "magnet" | "e2dk";
+} => {
+  const trimmedLink = link.trim();
+  if (!trimmedLink) {
+    return { valid: false, error: "Please enter a download link" };
+  }
+
+  // Check magnet link first
+  if (trimmedLink.startsWith("magnet:")) {
+    const result = validateMagnetLink(trimmedLink);
+    return {
+      valid: result.valid,
+      error: result.error,
+      linkType: "magnet",
+    };
+  }
+
+  // Check E2DK link
+  if (trimmedLink.startsWith("ed2k://")) {
+    const result = validateE2dkLink(trimmedLink);
+    return {
+      valid: result.valid,
+      error: result.error,
+      linkType: "e2dk",
+    };
+  }
+
+  return {
+    valid: false,
+    error:
+      "Invalid link format. Please provide either a magnet link (magnet:?xt=urn:btih:...) or an E2DK link (ed2k://|file|...|/)",
+    linkType: undefined,
+  };
+};

--- a/pikpak-plus-server/app/api/routes/tasks.py
+++ b/pikpak-plus-server/app/api/routes/tasks.py
@@ -12,7 +12,7 @@ from app.api.utils.dependencies import (
     get_cache_manager,
     get_scheduler
 )
-from app.utils.common import extract_magnet_hash
+from app.utils.common import extract_magnet_hash, extract_e2dk_hash, validate_link
 
 logger = logging.getLogger(__name__)
 
@@ -21,18 +21,26 @@ bp = Blueprint('tasks', __name__)
 
 
 def check_duplicate_task(url: str):
-    """Check if a task with the same magnet hash already exists"""
+    """Check if a task with the same hash already exists (supports both magnet and E2DK)"""
+    # Try to extract magnet hash first
     magnet_hash = extract_magnet_hash(url)
     if magnet_hash:
         supabase_service = get_supabase_service()
         return supabase_service.check_existing_task_by_hash(magnet_hash)
+    
+    # Try to extract E2DK hash
+    e2dk_hash = extract_e2dk_hash(url)
+    if e2dk_hash:
+        supabase_service = get_supabase_service()
+        return supabase_service.check_existing_task_by_hash(e2dk_hash)
+    
     return None
 
 
 @bp.route('/add', methods=['POST'])
 @require_auth
 def add_task():
-    """Add a new download task with file size validation and user tracking"""
+    """Add a new download task (magnet or E2DK) with file size validation and user tracking"""
     async def _async_add_task():
         # Get current user
         user_data = get_current_user()
@@ -58,6 +66,14 @@ def add_task():
             return jsonify({"error": "No URL provided"}), 400
 
         logger.info(f"Received add request for: {url}")
+
+        # Validate link type (magnet or E2DK)
+        is_valid, error_msg, link_type = validate_link(url)
+        if not is_valid:
+            logger.warning(f"Invalid link format for {url}: {error_msg}")
+            return jsonify({"error": error_msg}), 400
+
+        logger.info(f"Processing {link_type} link: {url}")
 
         # Check for existing task (deduplication)
         existing_task = check_duplicate_task(url)

--- a/pikpak-plus-server/app/utils/common.py
+++ b/pikpak-plus-server/app/utils/common.py
@@ -133,6 +133,69 @@ def validate_magnet_link(url: str) -> tuple[bool, str]:
     return True, ""
 
 
+def validate_e2dk_link(url: str) -> tuple[bool, str]:
+    """Validate that a URL is a valid E2DK (End-to-End Encrypted Download Key) link"""
+    if not url or not url.strip():
+        return False, "No URL provided"
+
+    url = url.strip()
+    
+    # E2DK links start with 'ed2k://' protocol
+    if not url.startswith("ed2k://"):
+        return False, "URL must be an E2DK link (starting with 'ed2k://')"
+
+    # Basic E2DK format validation: ed2k://|file|filename|size|hash|/
+    # Example: ed2k://|file|example.zip|123456|abcdef1234567890abcdef1234567890|/
+    try:
+        # Remove protocol prefix
+        content = url[7:]  # Remove 'ed2k://'
+        
+        if not content.startswith("|file|"):
+            return False, "Invalid E2DK format: must start with 'ed2k://|file|'"
+        
+        # Count pipes to ensure proper format (at least 5: |file|name|size|hash|/)
+        pipe_count = url.count("|")
+        if pipe_count < 5:
+            return False, "Invalid E2DK format: incomplete file information"
+        
+        if not url.endswith("|/"):
+            return False, "Invalid E2DK format: must end with '|/'"
+            
+        return True, ""
+    except Exception as e:
+        logger.error(f"E2DK validation error: {e}")
+        return False, f"E2DK validation failed: {str(e)}"
+
+
+def validate_link(url: str) -> tuple[bool, str, str]:
+    """
+    Validate a URL and determine its type (magnet or E2DK)
+    
+    Args:
+        url: The URL to validate
+    
+    Returns:
+        Tuple of (is_valid, error_message, link_type)
+        link_type can be 'magnet', 'e2dk', or 'unknown'
+    """
+    if not url or not url.strip():
+        return False, "No URL provided", "unknown"
+    
+    url = url.strip()
+    
+    # Check magnet link
+    if url.startswith("magnet:"):
+        valid, error = validate_magnet_link(url)
+        return valid, error, "magnet"
+    
+    # Check E2DK link
+    if url.startswith("ed2k://"):
+        valid, error = validate_e2dk_link(url)
+        return valid, error, "e2dk"
+    
+    return False, "URL must be either a magnet link (magnet:) or E2DK link (ed2k://)", "unknown"
+
+
 def extract_magnet_hash(url: str) -> Optional[str]:
     """
     Extract the info hash from a magnet link
@@ -160,5 +223,38 @@ def extract_magnet_hash(url: str) -> Optional[str]:
 
     except Exception as e:
         logger.error(f"Failed to extract hash from magnet link: {e}")
+
+    return None
+
+
+def extract_e2dk_hash(url: str) -> Optional[str]:
+    """
+    Extract the MD5 hash from an E2DK link
+
+    Args:
+        url: The E2DK link URL
+
+    Returns:
+        The MD5 hash if found, None otherwise
+    """
+    if not url or not url.startswith("ed2k://"):
+        return None
+
+    try:
+        # E2DK format: ed2k://|file|filename|size|hash|/
+        # Extract the parts between pipes
+        content = url[7:]  # Remove 'ed2k://'
+        parts = content.split("|")
+        
+        # parts[0] = 'file'
+        # parts[1] = filename
+        # parts[2] = size
+        # parts[3] = hash (MD5)
+        # parts[4] = '' (empty before final /)
+        
+        if len(parts) >= 4 and parts[0] == "file":
+            return parts[3].lower()
+    except Exception as e:
+        logger.error(f"Failed to extract hash from E2DK link: {e}")
 
     return None


### PR DESCRIPTION
## Overview
This PR adds comprehensive support for E2DK (End-to-End Encrypted Download Key) links alongside existing magnet link functionality.

## Changes Made

### Backend (pikpak-plus-server)
- **app/utils/common.py**: Added E2DK link validation and parsing functions
  - `validate_e2dk_link()`: Validates E2DK protocol links
  - `validate_link()`: Universal validator supporting both magnet and E2DK links
  - `extract_e2dk_hash()`: Extracts MD5 hash from E2DK links

- **app/api/routes/tasks.py**: Updated task addition endpoint
  - Added E2DK link validation in `/add` endpoint
  - Updated `check_duplicate_task()` to support both link types
  - Enhanced logging for link type processing

### Frontend (pikpak-plus-client)
- **magnet-utils.ts**: Extended link validation utilities
  - `validateE2dkLink()`: Validates E2DK format
  - `validateDownloadLink()`: Universal validator for both link types
  - Updated error messages to reflect support for both protocols

## Features
- ✅ Accept both magnet links (`magnet:...`) and E2DK links (`ed2k://...`)
- ✅ Proper format validation for both link types
- ✅ Hash extraction for deduplication support
- ✅ Comprehensive error handling and logging
- ✅ UI updates to reflect dual protocol support

## Format Support
- **Magnet**: `magnet:?xt=urn:btih:...`
- **E2DK**: `ed2k://|file|filename|size|hash|/`

## Testing
- Validate E2DK link format detection
- Test deduplication with E2DK hashes
- Verify error messages for invalid formats
- Test WhatsLink compatibility with E2DK links

## Breaking Changes
None - this is a backward-compatible feature addition.

## Related Issues
Implements E2DK link support for enhanced download protocol flexibility.